### PR TITLE
feat: add Docker/Dockge containerization files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.claude
+.gitignore
+Dockerfile
+compose.yaml
+.dockerignore
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:alpine
+
+COPY . /usr/share/nginx/html
+
+# Remove server version disclosure
+RUN sed -i 's/^.*server_tokens.*$/    server_tokens off;/' /etc/nginx/nginx.conf
+
+EXPOSE 80

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  stltexturizer:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    container_name: stltexturizer
+    restart: unless-stopped
+    ports:
+      - "8081:80"
+    volumes:
+      - /mnt/raid1/stltexturizer/logs:/var/log/nginx


### PR DESCRIPTION
Adds Dockerfile, compose.yaml, and .dockerignore to serve the static app via nginx:alpine. Compose follows Dockge conventions with the stack at /opt/stacks/stltexturizer/ and nginx logs bind-mounted to /mnt/raid1/stltexturizer/logs. No server-side volumes needed since all app state is client-side (browser storage only).