### PR TITLE
Fix silent corruption on malformed 3MF triangle indices

### DIFF
--- a/js/stlLoader.js
+++ b/js/stlLoader.js
@@ -305,17 +305,18 @@ function parse3MF(data) {
         vertices[i * 3 + 1] = parseFloat(vertEls[i].getAttribute('y'));
         vertices[i * 3 + 2] = parseFloat(vertEls[i].getAttribute('z'));
       }
-      const triangles = new Uint32Array(triEls.length * 3);
+      // Validate raw attrs before storing — Uint32Array coerces on write
+      // (NaN→0, negatives wrap), so post-hoc checks can't catch bad input.
+      const vertCount  = vertEls.length;
+      const triangles  = new Uint32Array(triEls.length * 3);
       for (let i = 0; i < triEls.length; i++) {
-        triangles[i * 3]     = parseInt(triEls[i].getAttribute('v1'), 10);
-        triangles[i * 3 + 1] = parseInt(triEls[i].getAttribute('v2'), 10);
-        triangles[i * 3 + 2] = parseInt(triEls[i].getAttribute('v3'), 10);
-      }
-
-      const vertCount = vertEls.length;
-      for (let i = 0; i < triangles.length; i++) {
-        if (triangles[i] < 0 || triangles[i] >= vertCount || isNaN(triangles[i])) {
-          throw new Error('Invalid triangle index in 3MF file');
+        for (let j = 0; j < 3; j++) {
+          const raw = triEls[i].getAttribute('v' + (j + 1));
+          const idx = (raw !== null && /^[0-9]+$/.test(raw.trim())) ? Number(raw) : NaN;
+          if (!Number.isInteger(idx) || idx >= vertCount) {
+            throw new Error('Invalid triangle index in 3MF file');
+          }
+          triangles[i * 3 + j] = idx;
         }
       }
 


### PR DESCRIPTION
`parse3MF` stores `v1/v2/v3` into a `Uint32Array` before validating. The array coerces NaN→0 (and wraps negatives), so the `isNaN` and `< 0` checks are unreachable: a missing or malformed index attribute becomes a valid-looking `0` and the triangle silently loads anchored at vertex 0 — a corrupt mesh headed for the slicer instead of the intended "Invalid triangle index in 3MF file" error.

Same spirit as #37's parser hardening. Fix: validate the raw attribute (digits-only, then range-check) before storing. This also rejects values `parseInt` silently truncates (`"3abc"` → 3) or reinterprets (`"0x10"` → 16). Valid files parse identically.

**Repro** — zip this as `3D/3dmodel.model` (plus the usual `[Content_Types].xml` / `_rels/.rels`) and load it; note `v2` is missing:

```xml
<?xml version="1.0"?>
<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
  <resources><object id="1" type="model"><mesh>
    <vertices><vertex x="0" y="0" z="0"/><vertex x="10" y="0" z="0"/><vertex x="0" y="10" z="0"/></vertices>
    <triangles><triangle v1="0" v3="2"/></triangles>
  </mesh></object></resources>
  <build><item objectid="1"/></build>
</model>
```

- **Before:** loads without error; the triangle uses vertex 0 where `v2` should be.
- **After:** throws "Invalid triangle index in 3MF file".
